### PR TITLE
Fix error file not found. tmp file is deleted before inserting rows to DB in VerticaToMySQLOperator bulk .

### DIFF
--- a/airflow/providers/mysql/transfers/vertica_to_mysql.py
+++ b/airflow/providers/mysql/transfers/vertica_to_mysql.py
@@ -133,21 +133,20 @@ class VerticaToMySqlOperator(BaseOperator):
                     count += 1
 
                 tmpfile.flush()
-        self._run_preoperator(mysql)
-        try:
-            self.log.info("Bulk inserting rows into MySQL...")
-            with closing(mysql.get_conn()) as conn, closing(conn.cursor()) as cursor:
-                cursor.execute(
-                    f"LOAD DATA LOCAL INFILE '{tmpfile.name}' "
-                    f"INTO TABLE {self.mysql_table} "
-                    f"LINES TERMINATED BY '\r\n' ({', '.join(selected_columns)})"
-                )
-                conn.commit()
-            tmpfile.close()
-            self.log.info("Inserted rows into MySQL %s", count)
-        except (MySQLdb.Error, MySQLdb.Warning):
-            self.log.info("Inserted rows into MySQL 0")
-            raise
+                self._run_preoperator(mysql)
+                try:
+                    self.log.info("Bulk inserting rows into MySQL...")
+                    with closing(mysql.get_conn()) as conn, closing(conn.cursor()) as cursor:
+                        cursor.execute(
+                            f"LOAD DATA LOCAL INFILE '{tmpfile.name}' "
+                            f"INTO TABLE {self.mysql_table} "
+                            f"LINES TERMINATED BY '\r\n' ({', '.join(selected_columns)})"
+                        )
+                        conn.commit()
+                    self.log.info("Inserted rows into MySQL %s", count)
+                except (MySQLdb.Error, MySQLdb.Warning):
+                    self.log.info("Inserted rows into MySQL 0")
+                    raise
 
     def _run_preoperator(self, mysql):
         if self.mysql_preoperator:

--- a/tests/providers/mysql/transfers/test_vertica_to_mysql.py
+++ b/tests/providers/mysql/transfers/test_vertica_to_mysql.py
@@ -31,17 +31,26 @@ except ImportError:
 
 
 def mock_get_conn():
+
+    class MockCol:
+        def __init__(self, name):
+            self.name = name
+
+    col_a = MockCol(name="a")
+    col_b = MockCol(name="b")
+    col_c = MockCol(name="c")
+
     commit_mock = mock.MagicMock()
     cursor_mock = mock.MagicMock(
-        execute=[],
-        fetchall=[["1", "2", "3"]],
-        description=["a", "b", "c"],
-        iterate=[["1", "2", "3"]],
+        description = [col_a, col_b, col_c]
     )
-    conn_mock = mock.MagicMock(
-        commit=commit_mock,
-        cursor=cursor_mock,
-    )
+    cursor_mock.execute.return_value=[]
+    cursor_mock.fetchall.return_value=[["1", "2", "3"]]
+    cursor_mock.iterate.return_value=[["1", "2", "3"]]
+    conn_mock = mock.MagicMock()
+    conn_mock.commit.return_value = commit_mock
+    conn_mock.cursor.return_value = cursor_mock
+
     return conn_mock
 
 


### PR DESCRIPTION
<!-- Please keep an empty line above the dashes. -->
 Issue: File not found error when using VerticaToMySQLOperator with bulk_load=true .
The issue occur because the temp file is automatically delete while code get out of the block.
fix: move the insertion logic into the NameTemporary file block and remove the explicit tmpFile.close() .
after the fix the replication work as expected.

---

